### PR TITLE
Fix: Ensure cleared `nextRunAt` when saving to db

### DIFF
--- a/lib/job/compute-next-run-at.ts
+++ b/lib/job/compute-next-run-at.ts
@@ -18,7 +18,7 @@ export const computeNextRunAt = function (this: Job): Job {
   const timezone = this.attrs.repeatTimezone;
   const { repeatAt } = this.attrs;
   const previousNextRunAt = this.attrs.nextRunAt || new Date();
-  this.attrs.nextRunAt = undefined;
+  this.attrs.nextRunAt = null;
 
   const dateForTimezone = (date: Date): moment.Moment => {
     const mdate: moment.Moment = moment(date);

--- a/test/job.js
+++ b/test/job.js
@@ -168,10 +168,10 @@ describe("Job", () => {
       expect(job.computeNextRunAt()).to.be(job);
     });
 
-    it("sets to undefined if no repeat at", () => {
+    it("sets to null if no repeat at", () => {
       job.attrs.repeatAt = null;
       job.computeNextRunAt();
-      expect(job.attrs.nextRunAt).to.be(undefined);
+      expect(job.attrs.nextRunAt).to.be(null);
     });
 
     it("it understands repeatAt times", () => {
@@ -185,10 +185,10 @@ describe("Job", () => {
       expect(job.attrs.nextRunAt.getMinutes()).to.be(d.getMinutes());
     });
 
-    it("sets to undefined if no repeat interval", () => {
+    it("sets to null if no repeat interval", () => {
       job.attrs.repeatInterval = null;
       job.computeNextRunAt();
-      expect(job.attrs.nextRunAt).to.be(undefined);
+      expect(job.attrs.nextRunAt).to.be(null);
     });
 
     it("it understands human intervals", () => {


### PR DESCRIPTION
When using a mongodb client configured with the option `ignoreUndefined` set to `true`, trying to clear the property `nextRunAt` from a job scheduled using `schedule` method by setting it to `undefined` does not take effect as it is ignored.

After computing `nextRunAt` property before running the job (`run.ts`), the change in value is not persisted, making it always behind `lastRunAt` after the first executing. This makes the program run the processor very quickly and indefinitely, exhausting the CPU's capacity.

Setting the property to `null` at the beginning of the computation makes sure the value is properly cleared.